### PR TITLE
fix: Incorrect handling of parallel CDStageDeploy

### DIFF
--- a/api/v1/cdstagedeploy_types.go
+++ b/api/v1/cdstagedeploy_types.go
@@ -6,12 +6,11 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 const (
 	CDStageDeployStatusFailed    = "failed"
 	CDStageDeployStatusRunning   = "running"
 	CDStageDeployStatusPending   = "pending"
+	CDStageDeployStatusInQueue   = "in-queue"
 	CDStageDeployStatusCompleted = "completed"
 )
 
@@ -39,7 +38,7 @@ type CodebaseTag struct {
 type CDStageDeployStatus struct {
 	// Specifies a current status of CDStageDeploy.
 	// +optional
-	// +kubebuilder:validation:Enum=failed;running;pending;completed
+	// +kubebuilder:validation:Enum=failed;running;pending;completed;in-queue
 	// +kubebuilder:default=pending
 	Status string `json:"status"`
 

--- a/config/crd/bases/v2.edp.epam.com_cdstagedeployments.yaml
+++ b/config/crd/bases/v2.edp.epam.com_cdstagedeployments.yaml
@@ -93,6 +93,7 @@ spec:
                 - running
                 - pending
                 - completed
+                - in-queue
                 type: string
             type: object
         type: object

--- a/controllers/codebaseimagestream/chain/factory.go
+++ b/controllers/codebaseimagestream/chain/factory.go
@@ -1,17 +1,13 @@
 package chain
 
 import (
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/epam/edp-codebase-operator/v2/controllers/codebaseimagestream/chain/handler"
 )
 
-var log = ctrl.Log.WithName("codebase-image-stream")
-
 func CreateDefChain(c client.Client) handler.CodebaseImageStreamHandler {
 	return PutCDStageDeploy{
 		client: c,
-		log:    log.WithName("create-chain").WithName("put-cd-stage-deploy"),
 	}
 }

--- a/controllers/codebaseimagestream/chain/handler/codebase_image_stream_handler.go
+++ b/controllers/codebaseimagestream/chain/handler/codebase_image_stream_handler.go
@@ -1,9 +1,11 @@
 package handler
 
 import (
+	"context"
+
 	codebaseApi "github.com/epam/edp-codebase-operator/v2/api/v1"
 )
 
 type CodebaseImageStreamHandler interface {
-	ServeRequest(imageStream *codebaseApi.CodebaseImageStream) error
+	ServeRequest(ctx context.Context, imageStream *codebaseApi.CodebaseImageStream) error
 }

--- a/controllers/codebaseimagestream/chain/put_cd_stage_deploy.go
+++ b/controllers/codebaseimagestream/chain/put_cd_stage_deploy.go
@@ -7,10 +7,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/go-logr/logr"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -23,7 +22,6 @@ import (
 
 type PutCDStageDeploy struct {
 	client client.Client
-	log    logr.Logger
 }
 
 type cdStageDeployCommand struct {
@@ -35,26 +33,25 @@ type cdStageDeployCommand struct {
 	Tags      []codebaseApi.CodebaseTag
 }
 
-const (
-	logNameKey = "name"
-)
+func (h PutCDStageDeploy) ServeRequest(ctx context.Context, imageStream *codebaseApi.CodebaseImageStream) error {
+	l := ctrl.LoggerFrom(ctx)
 
-func (h PutCDStageDeploy) ServeRequest(imageStream *codebaseApi.CodebaseImageStream) error {
-	l := h.log.WithValues(logNameKey, imageStream.Name)
-	l.Info("creating/updating CDStageDeploy.")
+	l.Info("Creating CDStageDeploy.")
 
-	if err := h.handleCodebaseImageStreamEnvLabels(imageStream); err != nil {
+	if err := h.handleCodebaseImageStreamEnvLabels(ctx, imageStream); err != nil {
 		return fmt.Errorf("failed to handle %v codebase image stream: %w", imageStream.Name, err)
 	}
 
-	l.Info("creating/updating CDStageDeploy has been finished.")
+	l.Info("Creating CDStageDeploy has been finished.")
 
 	return nil
 }
 
-func (h PutCDStageDeploy) handleCodebaseImageStreamEnvLabels(imageStream *codebaseApi.CodebaseImageStream) error {
+func (h PutCDStageDeploy) handleCodebaseImageStreamEnvLabels(ctx context.Context, imageStream *codebaseApi.CodebaseImageStream) error {
+	l := ctrl.LoggerFrom(ctx)
+
 	if imageStream.ObjectMeta.Labels == nil || len(imageStream.ObjectMeta.Labels) == 0 {
-		h.log.Info("codebase image stream does not contain env labels. skip CDStageDeploy creating...")
+		l.Info("CodebaseImageStream does not contain env labels. Skip CDStageDeploy creating.")
 		return nil
 	}
 
@@ -65,7 +62,7 @@ func (h PutCDStageDeploy) handleCodebaseImageStreamEnvLabels(imageStream *codeba
 			return errors.New(strings.Join(errs, "; "))
 		}
 
-		if err := h.putCDStageDeploy(envLabel, imageStream.Namespace, imageStream.Spec); err != nil {
+		if err := h.putCDStageDeploy(ctx, envLabel, imageStream.Namespace, imageStream.Spec); err != nil {
 			return err
 		}
 	}
@@ -85,66 +82,78 @@ func validateCbis(imageStream *codebaseApi.CodebaseImageStream, envLabel string,
 	}
 
 	if !labelValueRegexp.MatchString(envLabel) {
-		errs = append(errs, "Label must be in format cd-pipeline-name/stage-name")
+		errs = append(errs, "label must be in format cd-pipeline-name/stage-name")
 	}
 
 	return errs
 }
 
-func (h PutCDStageDeploy) putCDStageDeploy(envLabel, namespace string, spec codebaseApi.CodebaseImageStreamSpec) error {
+func (h PutCDStageDeploy) putCDStageDeploy(ctx context.Context, envLabel, namespace string, spec codebaseApi.CodebaseImageStreamSpec) error {
+	l := ctrl.LoggerFrom(ctx)
 	// use name for CDStageDeploy, it is converted from envLabel and cdpipeline/stage now is cdpipeline-stage
 	name := strings.ReplaceAll(envLabel, "/", "-")
 
-	stageDeploy, err := h.getCDStageDeploy(name, namespace)
+	skip, err := h.skipCDStageDeployCreation(ctx, envLabel, namespace)
 	if err != nil {
-		return fmt.Errorf("failed to get %v cd stage deploy: %w", name, err)
+		return fmt.Errorf("failed to check if CDStageDeploy exists: %w", err)
 	}
 
-	if stageDeploy != nil {
-		h.log.Info("CDStageDeploy already exists. skip creating.", logNameKey, stageDeploy.Name)
+	if skip {
+		l.Info("Skip CDStageDeploy creation.")
 
 		return nil
 	}
 
-	cdsd, err := getCreateCommand(envLabel, name, namespace, spec.Codebase, spec.Tags, log)
+	cdsd, err := getCreateCommand(ctx, envLabel, name, namespace, spec.Codebase, spec.Tags)
 	if err != nil {
 		return fmt.Errorf("failed to construct command to create %v cd stage deploy: %w", name, err)
 	}
 
-	if err := h.create(cdsd); err != nil {
+	if err = h.create(ctx, cdsd); err != nil {
 		return fmt.Errorf("failed to create %v cd stage deploy: %w", name, err)
 	}
 
 	return nil
 }
 
-func (h PutCDStageDeploy) getCDStageDeploy(name, namespace string) (*codebaseApi.CDStageDeploy, error) {
-	h.log.Info("getting cd stage deploy", logNameKey, name)
+func (h PutCDStageDeploy) skipCDStageDeployCreation(ctx context.Context, envLabel, namespace string) (bool, error) {
+	l := ctrl.LoggerFrom(ctx)
+	l.Info("Getting CDStageDeploys.")
 
-	ctx := context.Background()
-	i := &codebaseApi.CDStageDeploy{}
-	nn := types.NamespacedName{
-		Namespace: namespace,
-		Name:      name,
-	}
-
-	if err := h.client.Get(ctx, nn, i); err != nil {
-		if k8sErrors.IsNotFound(err) {
-			return nil, nil
-		}
-
-		return nil, fmt.Errorf("failed to fetch CDStageDeploy resource %q: %w", name, err)
-	}
-
-	return i, nil
-}
-
-func getCreateCommand(envLabel, name, namespace, codebase string, tags []codebaseApi.Tag, log logr.Logger) (*cdStageDeployCommand, error) {
 	env := strings.Split(envLabel, "/")
 
-	lastTag, err := codebaseimagestream.GetLastTag(tags, log)
+	list := &codebaseApi.CDStageDeployList{}
+	if err := h.client.List(
+		ctx,
+		list,
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			"app.edp.epam.com/cdpipeline": env[0],
+			"app.edp.epam.com/cdstage":    fmt.Sprintf("%s-%s", env[0], env[1]),
+		},
+	); err != nil {
+		return false, fmt.Errorf("failed to get CDStageDeploys: %w", err)
+	}
+
+	switch len(list.Items) {
+	case 0:
+		l.Info("CDStageDeploy is not present in cluster.")
+		return false, nil
+	case 1:
+		l.Info("One CDStageDeploy is present in cluster.")
+		return false, nil
+	default:
+		l.Info("More than one CDStageDeploy is present in cluster.")
+		return true, nil
+	}
+}
+
+func getCreateCommand(ctx context.Context, envLabel, name, namespace, codebase string, tags []codebaseApi.Tag) (*cdStageDeployCommand, error) {
+	env := strings.Split(envLabel, "/")
+
+	lastTag, err := codebaseimagestream.GetLastTag(tags, ctrl.LoggerFrom(ctx))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cdStageDeployCommand with name %v: %w", name, err)
+		return nil, fmt.Errorf("failed to get last tag: %w", err)
 	}
 
 	return &cdStageDeployCommand{
@@ -165,19 +174,18 @@ func getCreateCommand(envLabel, name, namespace, codebase string, tags []codebas
 	}, nil
 }
 
-func (h PutCDStageDeploy) create(command *cdStageDeployCommand) error {
-	log := h.log.WithValues(logNameKey, command.Name)
-	log.Info("cd stage deploy is not present in cluster. start creating...")
+func (h PutCDStageDeploy) create(ctx context.Context, command *cdStageDeployCommand) error {
+	l := ctrl.LoggerFrom(ctx)
+	l.Info("CDStageDeploy is not present in cluster. Start creating.")
 
-	ctx := context.Background()
 	stageDeploy := &codebaseApi.CDStageDeploy{
 		TypeMeta: metaV1.TypeMeta{
 			APIVersion: util.V2APIVersion,
 			Kind:       util.CDStageDeployKind,
 		},
 		ObjectMeta: metaV1.ObjectMeta{
-			Name:      command.Name,
-			Namespace: command.Namespace,
+			GenerateName: command.Name,
+			Namespace:    command.Namespace,
 		},
 		Spec: codebaseApi.CDStageDeploySpec{
 			Pipeline: command.Pipeline,
@@ -186,6 +194,11 @@ func (h PutCDStageDeploy) create(command *cdStageDeployCommand) error {
 			Tags:     command.Tags,
 		},
 	}
+
+	stageDeploy.SetLabels(map[string]string{
+		"app.edp.epam.com/cdpipeline": command.Pipeline,
+		"app.edp.epam.com/cdstage":    stageDeploy.GetStageCRName(),
+	})
 
 	stage := &pipelineApi.Stage{}
 	if err := h.client.Get(
@@ -208,7 +221,7 @@ func (h PutCDStageDeploy) create(command *cdStageDeployCommand) error {
 		return fmt.Errorf("failed to create CDStageDeploy resource %q: %w", command.Name, err)
 	}
 
-	log.Info("cd stage deploy has been created.")
+	l.Info("CDStageDeploy has been created.")
 
 	return nil
 }

--- a/controllers/codebaseimagestream/chain/put_cd_stage_deploy_test.go
+++ b/controllers/codebaseimagestream/chain/put_cd_stage_deploy_test.go
@@ -2,335 +2,404 @@ package chain
 
 import (
 	"context"
-	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	cdPipeApi "github.com/epam/edp-cd-pipeline-operator/v2/api/v1"
+	pipelineAPi "github.com/epam/edp-cd-pipeline-operator/v2/api/v1"
 
 	codebaseApi "github.com/epam/edp-codebase-operator/v2/api/v1"
 )
 
-func TestPutCDStageDeploy_ShouldNotFailOnEmptyLables(t *testing.T) {
-	cis := &codebaseApi.CodebaseImageStream{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "cbis-name",
-			Namespace: "stub-namespace",
-		},
-		Spec: codebaseApi.CodebaseImageStreamSpec{
-			Codebase: "cb-name",
-		},
-	}
-
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(schema.GroupVersion{Group: "v2.edp.epam.com", Version: "v1"}, cis)
-	fakeCl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cis).Build()
-
-	chain := PutCDStageDeploy{
-		client: fakeCl,
-		log:    logr.Discard(),
-	}
-
-	err := chain.ServeRequest(cis)
-	assert.NoError(t, err)
-}
-
-func TestPutCDStageDeploy_ShouldFailWithEmptyCodebase(t *testing.T) {
-	cis := &codebaseApi.CodebaseImageStream{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "cbis-name",
-			Namespace: "stub-namespace",
-			Labels: map[string]string{
-				"stage-name": "cb-name",
-			},
-		},
-		Spec: codebaseApi.CodebaseImageStreamSpec{},
-	}
-
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(schema.GroupVersion{Group: "v2.edp.epam.com", Version: "v1"}, cis)
-	fakeCl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cis).Build()
-
-	chain := PutCDStageDeploy{
-		client: fakeCl,
-		log:    logr.Discard(),
-	}
-
-	err := chain.ServeRequest(cis)
-	assert.Error(t, err)
-
-	if !strings.Contains(err.Error(), "codebase is not defined in spec") {
-		t.Fatalf("wrong error returned: %s", err.Error())
-	}
-}
-
-func TestPutCDStageDeploy_ShouldFailWithEmptyTags(t *testing.T) {
-	cis := &codebaseApi.CodebaseImageStream{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "cbis-name",
-			Namespace: "stub-namespace",
-			Labels: map[string]string{
-				"stage-name": "cb-name",
-			},
-		},
-		Spec: codebaseApi.CodebaseImageStreamSpec{
-			Codebase: "cb-name",
-		},
-	}
-
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(schema.GroupVersion{Group: "v2.edp.epam.com", Version: "v1"}, cis)
-	fakeCl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cis).Build()
-
-	chain := PutCDStageDeploy{
-		client: fakeCl,
-		log:    logr.Discard(),
-	}
-
-	err := chain.ServeRequest(cis)
-	assert.Error(t, err)
-
-	if !strings.Contains(err.Error(), "tags are not defined in spec") {
-		t.Fatalf("wrong error returned: %s", err.Error())
-	}
-}
-
-func TestPutCDStageDeploy_ShouldFailWithInvalidLabels(t *testing.T) {
-	cis := &codebaseApi.CodebaseImageStream{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "cbis-name",
-			Namespace: "stub-namespace",
-			Labels: map[string]string{
-				"stage-name": "cb-name",
-			},
-		},
-		Spec: codebaseApi.CodebaseImageStreamSpec{
-			Codebase: "cb-name",
-			Tags: []codebaseApi.Tag{
-				{
-					Name:    "master-0.0.1-1",
-					Created: "2021-10-20T14:02:31",
-				},
-			},
-		},
-	}
-
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(schema.GroupVersion{Group: "v2.edp.epam.com", Version: "v1"}, cis)
-	fakeCl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cis).Build()
-
-	chain := PutCDStageDeploy{
-		client: fakeCl,
-		log:    logr.Discard(),
-	}
-
-	err := chain.ServeRequest(cis)
-	assert.Error(t, err)
-
-	if !strings.Contains(err.Error(), "Label must be in format cd-pipeline-name/stage-name") {
-		t.Fatalf("wrong error returned: %s", err.Error())
-	}
-}
-
-func TestPutCDStageDeploy_CdstagedeployShouldFailOnSearch(t *testing.T) {
-	cis := &codebaseApi.CodebaseImageStream{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "cbis-name",
-			Namespace: "stub-namespace",
-			Labels: map[string]string{
-				"pipeline-name/stage-name": "",
-			},
-		},
-		Spec: codebaseApi.CodebaseImageStreamSpec{
-			Codebase: "cb-name",
-			Tags: []codebaseApi.Tag{
-				{
-					Name:    "master-0.0.1-1",
-					Created: "2021-10-20T14:02:31",
-				},
-			},
-		},
-	}
-
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(schema.GroupVersion{Group: "v2.edp.epam.com", Version: "v1"}, cis)
-	fakeCl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cis).Build()
-
-	chain := PutCDStageDeploy{
-		client: fakeCl,
-		log:    logr.Discard(),
-	}
-
-	err := chain.ServeRequest(cis)
-	assert.Error(t, err)
-
-	if !strings.Contains(err.Error(), "failed to get pipeline-name-stage-name cd stage deploy") {
-		t.Fatalf("wrong error returned: %s", err.Error())
-	}
-}
-
-func TestPutCDStageDeploy_ShouldPassWhenCdstagedeployExist(t *testing.T) {
-	cis := &codebaseApi.CodebaseImageStream{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "cbis-name",
-			Namespace: "stub-namespace",
-			Labels: map[string]string{
-				"pipeline-name/stage-name": "",
-			},
-		},
-		Spec: codebaseApi.CodebaseImageStreamSpec{
-			Codebase: "cb-name",
-			Tags: []codebaseApi.Tag{
-				{
-					Name:    "master-0.0.1-1",
-					Created: "2021-10-20T14:02:31",
-				},
-			},
-		},
-	}
-
-	cdsd := &codebaseApi.CDStageDeploy{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "pipeline-name-stage-name",
-			Namespace: "stub-namespace",
-		},
-		Spec: codebaseApi.CDStageDeploySpec{},
-	}
-
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(schema.GroupVersion{Group: "v2.edp.epam.com", Version: "v1"}, cis, cdsd)
-	fakeCl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cis, cdsd).Build()
-
-	chain := PutCDStageDeploy{
-		client: fakeCl,
-		log:    logr.Discard(),
-	}
-
-	err := chain.ServeRequest(cis)
-	assert.NoError(t, err)
-
-	if err != nil {
-		t.Fatalf("unexpected error returned: %s", err.Error())
-	}
-}
-
-func TestPutCDStageDeploy_ShouldCreateCdstagedeploy(t *testing.T) {
-	cis := &codebaseApi.CodebaseImageStream{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "cbis-name",
-			Namespace: "stub-namespace",
-			Labels: map[string]string{
-				"pipeline-name/stage-name": "",
-			},
-		},
-		Spec: codebaseApi.CodebaseImageStreamSpec{
-			Codebase: "cb-name",
-			Tags: []codebaseApi.Tag{
-				{
-					Name:    "master-0.0.1-1",
-					Created: "2022-04-12T12:54:04Z",
-				},
-				{
-					Name:    "master-0.0.1-2",
-					Created: "2022-04-13T12:54:04Z",
-				},
-			},
-		},
-	}
-
-	cdsd := &codebaseApi.CDStageDeploy{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "cdsd-name",
-			Namespace: "stub-namespace",
-		},
-		Spec: codebaseApi.CDStageDeploySpec{},
-	}
-
-	stage := &cdPipeApi.Stage{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "pipeline-name-stage-name",
-			Namespace: "stub-namespace",
-		},
-	}
+func TestPutCDStageDeploy_ServeRequest(t *testing.T) {
+	t.Parallel()
 
 	scheme := runtime.NewScheme()
 	require.NoError(t, codebaseApi.AddToScheme(scheme))
-	require.NoError(t, cdPipeApi.AddToScheme(scheme))
+	require.NoError(t, pipelineAPi.AddToScheme(scheme))
 
-	fakeCl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cis, cdsd, stage).Build()
-
-	chain := PutCDStageDeploy{
-		client: fakeCl,
-		log:    logr.Discard(),
-	}
-
-	err := chain.ServeRequest(cis)
-	assert.NoError(t, err)
-
-	cdsdResp := &codebaseApi.CDStageDeploy{}
-	err = fakeCl.Get(context.TODO(),
-		types.NamespacedName{
-			Name:      "pipeline-name-stage-name",
-			Namespace: "stub-namespace",
-		},
-		cdsdResp)
-	assert.NoError(t, err)
-	assert.Equal(t, cdsdResp.Spec.Tag.Tag, "master-0.0.1-2")
-}
-
-func TestPutCDStageDeploy_ShouldFailWithIncorrectTagsTimestamp(t *testing.T) {
-	cis := &codebaseApi.CodebaseImageStream{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "cbis-name",
-			Namespace: "stub-namespace",
-			Labels: map[string]string{
-				"pipeline-name/stage-name": "",
-			},
-		},
-		Spec: codebaseApi.CodebaseImageStreamSpec{
-			Codebase: "cb-name",
-			Tags: []codebaseApi.Tag{
-				{
-					Name:    "master-0.0.1-1",
-					Created: "2021-10-20",
+	tests := []struct {
+		name        string
+		imageStream *codebaseApi.CodebaseImageStream
+		client      func(t *testing.T) client.Client
+		wantErr     require.ErrorAssertionFunc
+		want        func(t *testing.T, k8scl client.Client)
+	}{
+		{
+			name: "successfully created CDStageDeploy",
+			imageStream: &codebaseApi.CodebaseImageStream{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-image-stream",
+					Namespace: "default",
+					Labels: map[string]string{
+						"ci/dev": "",
+					},
 				},
-				{
-					Name:    "master-0.0.1-2",
-					Created: "14:11:11",
+				Spec: codebaseApi.CodebaseImageStreamSpec{
+					Codebase:  "app",
+					ImageName: "latest",
+					Tags:      []codebaseApi.Tag{{Name: "latest", Created: time.Now().Format(time.RFC3339)}},
 				},
 			},
+			client: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(
+						&pipelineAPi.Stage{
+							ObjectMeta: metaV1.ObjectMeta{
+								Name:      "ci-dev",
+								Namespace: "default",
+							},
+						},
+						&codebaseApi.CDStageDeploy{
+							ObjectMeta: metaV1.ObjectMeta{
+								Name:      "test-stage-deploy",
+								Namespace: "default",
+								Labels: map[string]string{
+									"app.edp.epam.com/cdpipeline": "ci",
+									"app.edp.epam.com/cdstage":    "ci-prod",
+								},
+							},
+						},
+					).Build()
+			},
+			wantErr: require.NoError,
+			want: func(t *testing.T, k8scl client.Client) {
+				cdStageDeploys := &codebaseApi.CDStageDeployList{}
+				require.NoError(t,
+					k8scl.List(
+						context.Background(),
+						cdStageDeploys,
+						client.InNamespace("default"),
+						client.MatchingLabels{
+							"app.edp.epam.com/cdpipeline": "ci",
+							"app.edp.epam.com/cdstage":    "ci-dev",
+						}))
+				require.Len(t, cdStageDeploys.Items, 1)
+			},
+		},
+		{
+			name: "successfully created CDStageDeploy if one CDStageDeploy already exists",
+			imageStream: &codebaseApi.CodebaseImageStream{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-image-stream",
+					Namespace: "default",
+					Labels: map[string]string{
+						"ci/dev": "",
+					},
+				},
+				Spec: codebaseApi.CodebaseImageStreamSpec{
+					Codebase:  "app",
+					ImageName: "latest",
+					Tags:      []codebaseApi.Tag{{Name: "latest", Created: time.Now().Format(time.RFC3339)}},
+				},
+			},
+			client: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(
+						&pipelineAPi.Stage{
+							ObjectMeta: metaV1.ObjectMeta{
+								Name:      "ci-dev",
+								Namespace: "default",
+							},
+						},
+						&codebaseApi.CDStageDeploy{
+							ObjectMeta: metaV1.ObjectMeta{
+								Name:      "test-stage-deploy",
+								Namespace: "default",
+								Labels: map[string]string{
+									"app.edp.epam.com/cdpipeline": "ci",
+									"app.edp.epam.com/cdstage":    "ci-dev",
+								},
+							},
+						},
+					).Build()
+			},
+			wantErr: require.NoError,
+			want: func(t *testing.T, k8scl client.Client) {
+				cdStageDeploys := &codebaseApi.CDStageDeployList{}
+				require.NoError(t,
+					k8scl.List(
+						context.Background(),
+						cdStageDeploys,
+						client.InNamespace("default"),
+						client.MatchingLabels{
+							"app.edp.epam.com/cdpipeline": "ci",
+							"app.edp.epam.com/cdstage":    "ci-dev",
+						}))
+				require.Len(t, cdStageDeploys.Items, 2)
+			},
+		},
+		{
+			name: "skip CDStageDeploy creation if more than one CDStageDeploy already exists",
+			imageStream: &codebaseApi.CodebaseImageStream{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-image-stream",
+					Namespace: "default",
+					Labels: map[string]string{
+						"ci/dev": "",
+					},
+				},
+				Spec: codebaseApi.CodebaseImageStreamSpec{
+					Codebase:  "app",
+					ImageName: "latest",
+					Tags:      []codebaseApi.Tag{{Name: "latest", Created: time.Now().Format(time.RFC3339)}},
+				},
+			},
+			client: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(
+						&pipelineAPi.Stage{
+							ObjectMeta: metaV1.ObjectMeta{
+								Name:      "ci-dev",
+								Namespace: "default",
+							},
+						},
+						&codebaseApi.CDStageDeploy{
+							ObjectMeta: metaV1.ObjectMeta{
+								Name:      "test-stage-deploy1",
+								Namespace: "default",
+								Labels: map[string]string{
+									"app.edp.epam.com/cdpipeline": "ci",
+									"app.edp.epam.com/cdstage":    "ci-dev",
+								},
+							},
+						},
+						&codebaseApi.CDStageDeploy{
+							ObjectMeta: metaV1.ObjectMeta{
+								Name:      "test-stage-deploy2",
+								Namespace: "default",
+								Labels: map[string]string{
+									"app.edp.epam.com/cdpipeline": "ci",
+									"app.edp.epam.com/cdstage":    "ci-dev",
+								},
+							},
+						},
+					).Build()
+			},
+			wantErr: require.NoError,
+			want: func(t *testing.T, k8scl client.Client) {
+				cdStageDeploys := &codebaseApi.CDStageDeployList{}
+				require.NoError(t,
+					k8scl.List(
+						context.Background(),
+						cdStageDeploys,
+						client.InNamespace("default"),
+						client.MatchingLabels{
+							"app.edp.epam.com/cdpipeline": "ci",
+							"app.edp.epam.com/cdstage":    "ci-dev",
+						}))
+				require.Len(t, cdStageDeploys.Items, 2)
+			},
+		},
+		{
+			name: "failed to create CDStageDeploy - CDStage not found",
+			imageStream: &codebaseApi.CodebaseImageStream{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-image-stream",
+					Namespace: "default",
+					Labels: map[string]string{
+						"ci/dev": "",
+					},
+				},
+				Spec: codebaseApi.CodebaseImageStreamSpec{
+					Codebase:  "app",
+					ImageName: "latest",
+					Tags:      []codebaseApi.Tag{{Name: "latest", Created: time.Now().Format(time.RFC3339)}},
+				},
+			},
+			client: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects().
+					Build()
+			},
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "failed to get CDStage")
+			},
+			want: func(t *testing.T, k8scl client.Client) {},
+		},
+		{
+			name: "failed to create CDStageDeploy - invalid tag",
+			imageStream: &codebaseApi.CodebaseImageStream{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-image-stream",
+					Namespace: "default",
+					Labels: map[string]string{
+						"ci/dev": "",
+					},
+				},
+				Spec: codebaseApi.CodebaseImageStreamSpec{
+					Codebase:  "app",
+					ImageName: "latest",
+					Tags:      []codebaseApi.Tag{{Name: "latest", Created: "invalid"}},
+				},
+			},
+			client: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects().
+					Build()
+			},
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "failed to get last tag")
+			},
+			want: func(t *testing.T, k8scl client.Client) {},
+		},
+		{
+			name: "failed to create CDStageDeploy - invalid env label",
+			imageStream: &codebaseApi.CodebaseImageStream{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-image-stream",
+					Namespace: "default",
+					Labels: map[string]string{
+						"invalid": "",
+					},
+				},
+				Spec: codebaseApi.CodebaseImageStreamSpec{
+					Codebase:  "app",
+					ImageName: "latest",
+				},
+			},
+			client: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects().
+					Build()
+			},
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "label must be in format cd-pipeline-name/stage-name")
+			},
+			want: func(t *testing.T, k8scl client.Client) {},
+		},
+		{
+			name: "failed to create CDStageDeploy - no tags",
+			imageStream: &codebaseApi.CodebaseImageStream{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-image-stream",
+					Namespace: "default",
+					Labels: map[string]string{
+						"ci/dev": "",
+					},
+				},
+				Spec: codebaseApi.CodebaseImageStreamSpec{
+					Codebase:  "app",
+					ImageName: "latest",
+				},
+			},
+			client: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects().
+					Build()
+			},
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "tags are not defined in spec")
+			},
+			want: func(t *testing.T, k8scl client.Client) {},
+		},
+		{
+			name: "failed to create CDStageDeploy - no codebase",
+			imageStream: &codebaseApi.CodebaseImageStream{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-image-stream",
+					Namespace: "default",
+					Labels: map[string]string{
+						"ci/dev": "",
+					},
+				},
+				Spec: codebaseApi.CodebaseImageStreamSpec{
+					Codebase:  "",
+					ImageName: "latest",
+				},
+			},
+			client: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects().
+					Build()
+			},
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "codebase is not defined in spec")
+			},
+			want: func(t *testing.T, k8scl client.Client) {},
+		},
+		{
+			name: "no env labels - skip CDStageDeploy creation",
+			imageStream: &codebaseApi.CodebaseImageStream{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-image-stream",
+					Namespace: "default",
+				},
+				Spec: codebaseApi.CodebaseImageStreamSpec{
+					Codebase:  "app",
+					ImageName: "latest",
+					Tags:      []codebaseApi.Tag{{Name: "latest", Created: time.Now().Format(time.RFC3339)}},
+				},
+			},
+			client: func(t *testing.T) client.Client {
+				return fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(
+						&pipelineAPi.Stage{
+							ObjectMeta: metaV1.ObjectMeta{
+								Name:      "ci-dev",
+								Namespace: "default",
+							},
+						},
+						&codebaseApi.CDStageDeploy{
+							ObjectMeta: metaV1.ObjectMeta{
+								Name:      "test-stage-deploy",
+								Namespace: "default",
+								Labels: map[string]string{
+									"app.edp.epam.com/cdpipeline": "ci",
+									"app.edp.epam.com/cdstage":    "ci-prod",
+								},
+							},
+						},
+					).Build()
+			},
+			wantErr: require.NoError,
+			want: func(t *testing.T, k8scl client.Client) {
+				cdStageDeploys := &codebaseApi.CDStageDeployList{}
+				require.NoError(t,
+					k8scl.List(
+						context.Background(),
+						cdStageDeploys,
+						client.InNamespace("default"),
+						client.MatchingLabels{
+							"app.edp.epam.com/cdpipeline": "ci",
+							"app.edp.epam.com/cdstage":    "ci-dev",
+						}))
+				require.Len(t, cdStageDeploys.Items, 0)
+			},
 		},
 	}
 
-	cdsd := &codebaseApi.CDStageDeploy{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "cdsd-name",
-			Namespace: "stub-namespace",
-		},
-		Spec: codebaseApi.CDStageDeploySpec{},
-	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(schema.GroupVersion{Group: "v2.edp.epam.com", Version: "v1"}, cis, cdsd)
-	fakeCl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cis, cdsd).Build()
-
-	chain := PutCDStageDeploy{
-		client: fakeCl,
-		log:    logr.Discard(),
-	}
-
-	err := chain.ServeRequest(cis)
-	assert.Error(t, err)
-
-	if !strings.Contains(err.Error(), "failed to construct command to create pipeline-name-stage-name cd stage deploy") {
-		t.Fatalf("wrong error returned: %s", err.Error())
+			h := PutCDStageDeploy{
+				client: tt.client(t),
+			}
+			tt.wantErr(t, h.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), tt.imageStream))
+			tt.want(t, h.client)
+		})
 	}
 }

--- a/controllers/codebaseimagestream/codebaseimagestream_controller.go
+++ b/controllers/codebaseimagestream/codebaseimagestream_controller.go
@@ -91,7 +91,7 @@ func (r *ReconcileCodebaseImageStream) Reconcile(ctx context.Context, request re
 		return reconcile.Result{}, fmt.Errorf("failed to fetch CodebaseImageStream %q: %w", request.Name, err)
 	}
 
-	if err := chain.CreateDefChain(r.client).ServeRequest(i); err != nil {
+	if err := chain.CreateDefChain(r.client).ServeRequest(ctx, i); err != nil {
 		return reconcile.Result{}, fmt.Errorf("fail during CodebaseImageStream default chain: %w", err)
 	}
 

--- a/deploy-templates/crds/v2.edp.epam.com_cdstagedeployments.yaml
+++ b/deploy-templates/crds/v2.edp.epam.com_cdstagedeployments.yaml
@@ -93,6 +93,7 @@ spec:
                 - running
                 - pending
                 - completed
+                - in-queue
                 type: string
             type: object
         type: object

--- a/docs/api.md
+++ b/docs/api.md
@@ -229,7 +229,7 @@ CDStageDeployStatus defines the observed state of CDStageDeploy.
         <td>
           Specifies a current status of CDStageDeploy.<br/>
           <br/>
-            <i>Enum</i>: failed, running, pending, completed<br/>
+            <i>Enum</i>: failed, running, pending, completed, in-queue<br/>
             <i>Default</i>: pending<br/>
         </td>
         <td>false</td>


### PR DESCRIPTION
# Pull Request Template

## Description
Added in-queue status for CDStageDeploy.
This status is for CDStageDeploy,
which waits for the previous deployment to be ready. We can only have one CDStageDeploy status in-queue; all other  CDStageDeploy will be skipped.
This will allow us to get the latest versions
and not run redundant deployments.

Fixes #71 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Unit tests, manual testing.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits.