### PR TITLE
fix: Ensure ingress has proper labeling (#83)

### DIFF
--- a/controllers/gitserver/create_event_listener.go
+++ b/controllers/gitserver/create_event_listener.go
@@ -153,6 +153,9 @@ func (h *CreateEventListener) createIngress(ctx context.Context, gitServer *code
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: gitServer.Namespace,
+			Labels: map[string]string{
+				"app.edp.epam.com/gitServer": gitServer.Name,
+			},
 		},
 		Spec: networkingv1.IngressSpec{
 			Rules: []networkingv1.IngressRule{


### PR DESCRIPTION
We need to ensure ingress has proper labeling with the name of GitServer

Fixes #83 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
