### PR TITLE
feat: Skip Ingress creation if GitServer.spec.WebhookUrl is set

### DIFF
--- a/api/v1/git_server_types.go
+++ b/api/v1/git_server_types.go
@@ -36,7 +36,7 @@ type GitServerSpec struct {
 	SkipWebhookSSLVerification bool `json:"skipWebhookSSLVerification"`
 
 	// WebhookUrl is a URL for webhook that will be created in the git provider.
-	// If it is not set, a webhook will be created from Ingress with the name "event-listener".
+	// If not set, a new EventListener and Ingress will be created and used for webhooks.
 	// +optional
 	// +kubebuilder:example:=`https://webhook-url.com`
 	WebhookUrl string `json:"webhookUrl,omitempty"`

--- a/config/crd/bases/v2.edp.epam.com_gitservers.yaml
+++ b/config/crd/bases/v2.edp.epam.com_gitservers.yaml
@@ -84,7 +84,7 @@ spec:
               webhookUrl:
                 description: |-
                   WebhookUrl is a URL for webhook that will be created in the git provider.
-                  If it is not set, a webhook will be created from Ingress with the name "event-listener".
+                  If not set, a new EventListener and Ingress will be created and used for webhooks.
                 example: https://webhook-url.com
                 type: string
             required:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -74,10 +74,20 @@ rules:
   - update
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
   - route.openshift.io
   resources:
   - routes
   verbs:
+  - create
   - get
   - list
   - watch

--- a/controllers/gitserver/create_event_listener.go
+++ b/controllers/gitserver/create_event_listener.go
@@ -28,6 +28,13 @@ func NewCreateEventListener(k8sClient client.Client) *CreateEventListener {
 }
 
 func (h *CreateEventListener) ServeRequest(ctx context.Context, gitServer *codebaseApi.GitServer) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	if gitServer.Spec.WebhookUrl != "" {
+		log.Info("Skip creating EventListener because webhook URL is set")
+		return nil
+	}
+
 	if err := h.createEventListener(ctx, gitServer); err != nil {
 		return err
 	}

--- a/deploy-templates/crds/v2.edp.epam.com_gitservers.yaml
+++ b/deploy-templates/crds/v2.edp.epam.com_gitservers.yaml
@@ -84,7 +84,7 @@ spec:
               webhookUrl:
                 description: |-
                   WebhookUrl is a URL for webhook that will be created in the git provider.
-                  If it is not set, a webhook will be created from Ingress with the name "event-listener".
+                  If not set, a new EventListener and Ingress will be created and used for webhooks.
                 example: https://webhook-url.com
                 type: string
             required:

--- a/docs/api.md
+++ b/docs/api.md
@@ -1164,7 +1164,7 @@ GitServerSpec defines the desired state of GitServer.
         <td>string</td>
         <td>
           WebhookUrl is a URL for webhook that will be created in the git provider.
-If it is not set, a webhook will be created from Ingress with the name "event-listener".<br/>
+If not set, a new EventListener and Ingress will be created and used for webhooks.<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
# Pull Request Template

## Description
Check GitServer.spec.WebhookUrl. If it is set, don't create EventListener and Ingress.

Fixes #95 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Unit tests.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits.