### PR TITLE
feat: Add GitServer reconciliation status

### DIFF
--- a/api/v1/git_server_types.go
+++ b/api/v1/git_server_types.go
@@ -51,6 +51,21 @@ type GitServerStatus struct {
 	// Connected shows if operator is connected to git server.
 	// +optional
 	Connected bool `json:"connected"`
+
+	// Status indicates the current status of the GitServer.
+	// Possible values are: ok, failed.
+	// +optional
+	Status string `json:"status,omitempty"`
+}
+
+func (in *GitServerStatus) SetFailed(err string) {
+	in.Error = err
+	in.Status = "failed"
+}
+
+func (in *GitServerStatus) SetSuccess() {
+	in.Error = ""
+	in.Status = "ok"
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/v2.edp.epam.com_gitservers.yaml
+++ b/config/crd/bases/v2.edp.epam.com_gitservers.yaml
@@ -102,6 +102,11 @@ spec:
               error:
                 description: Error represents error message if something went wrong.
                 type: string
+              status:
+                description: |-
+                  Status indicates the current status of the GitServer.
+                  Possible values are: ok, failed.
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/gitserver/gitserver_controller_test.go
+++ b/controllers/gitserver/gitserver_controller_test.go
@@ -264,6 +264,10 @@ func TestReconcileGitServer_ServerUnavailable(t *testing.T) {
 	assert.Equal(t, res.RequeueAfter, defaultRequeueTime)
 	require.Error(t, loggerSink.LastError())
 	assert.Contains(t, loggerSink.LastError().Error(), "failed to establish connection to Git Server")
+
+	testedGitServer := &codebaseApi.GitServer{}
+	require.NoError(t, fakeCl.Get(context.Background(), req.NamespacedName, testedGitServer))
+	assert.Equal(t, "failed", testedGitServer.Status.Status)
 }
 
 func TestReconcileGitServer_InvalidSSHKey(t *testing.T) {

--- a/deploy-templates/crds/v2.edp.epam.com_gitservers.yaml
+++ b/deploy-templates/crds/v2.edp.epam.com_gitservers.yaml
@@ -102,6 +102,11 @@ spec:
               error:
                 description: Error represents error message if something went wrong.
                 type: string
+              status:
+                description: |-
+                  Status indicates the current status of the GitServer.
+                  Possible values are: ok, failed.
+                type: string
             type: object
         type: object
     served: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -1201,6 +1201,14 @@ GitServerStatus defines the observed state of GitServer.
           Error represents error message if something went wrong.<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>status</b></td>
+        <td>string</td>
+        <td>
+          Status indicates the current status of the GitServer.
+Possible values are: ok, failed.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 


### PR DESCRIPTION
# Pull Request Template

## Description
Add GitServer reconciliation status failed/ok.
Example:
```yaml
apiVersion: v2.edp.epam.com/v1
kind: GitServer
metadata:
  name: gerrit
status:
  connected: true
  status: ok
```

Fixes #97 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Manual testing.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits.
