### PR TITLE
feat: Add support for C/C++ languages (#108)

### DIFF
--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -8,9 +8,28 @@ import (
 )
 
 var allowedCodebaseSettings = map[string][]string{
-	"add_repo_strategy": {"create", "clone", "import"},
-	"language": {"java", "dotnet", "javascript",
-		"groovy-pipeline", "other", "go", "python", "terraform", "rego", "container", "helm", "csharp", "hcl"},
+	"add_repo_strategy": {
+		"clone",
+		"create",
+		"import",
+	},
+	"language": {
+		"c",
+		"container",
+		"cpp",
+		"csharp",
+		"dotnet",
+		"go",
+		"groovy-pipeline",
+		"hcl",
+		"helm",
+		"java",
+		"javascript",
+		"other",
+		"python",
+		"rego",
+		"terraform",
+	},
 }
 
 func IsCodebaseValid(codebase *codebaseApi.Codebase) error {


### PR DESCRIPTION
This pull request extends the capabilities of KubeRocketCI to support the automated build and deployment of C and C++ applications using both Make and CMake as build systems. This enhancement includes the creation and integration of new pipelines tailored for these projects and updates to the codebase specification.

Fixes #108 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
The following tests were conducted to verify the changes:

1. Unit tests for the new pipeline templates.
2. Integration tests to ensure compatibility with existing KubeRocketCI features.
3. End-to-end tests simulating real-world application builds and deployments.
4. Staging environment tests to verify Docker container deployment and execution in Kubernetes.

To reproduce, follow these steps:
1. Configure a sample C or C++ project using Make or CMake.
2. Set up the CI/CD pipeline using the new templates.
3. Run the pipeline and verify the build and deployment processes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contain one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
This enhancement aims to streamline the CI/CD processes for C/C++ applications, ensuring efficient, consistent, and error-free builds and deployments, especially for projects targeting Kubernetes environments. The codebase specification has been updated to support both cmake and make for C and C++ with the following fields:
- buildTool: cmake | make
- lang: c | cpp
- framework: none