### PR TITLE
chore: Do not rely on rpm changelog during build process (#116)

### DIFF
--- a/build/templates/applications/rpm-package/java/spec.tmpl
+++ b/build/templates/applications/rpm-package/java/spec.tmpl
@@ -1,3 +1,6 @@
+%global source_date_epoch_from_changelog 0
+%define debug_package %{nil}
+
 %if 0%{?RELEASE_NUMBER:1} != 0
 %define rel %{?RELEASE_NUMBER}
 %else
@@ -13,7 +16,7 @@
 Name:           {{.Name}}
 Version:        %{ver}
 Release:        %{rel}
-Summary:        {{.Name}} Application
+Summary:        {{.Name}} application
 ExclusiveArch:  %{_arch}
 
 License:        Apache-2.0
@@ -26,10 +29,8 @@ Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
 
-%define debug_package %{nil}
-
 %description
-Hello World Application
+{{.Name}} application
 
 %prep
 %setup -q


### PR DESCRIPTION
Avoid using changelog datetime during the build process to improve build stability and reliability.

Related issue #116

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
checked during build

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):
N/A

## Additional context
N/A