### PR TITLE
chore: Update default rpm spec and service templates (#123)

### DIFF
--- a/build/templates/applications/rpm-package/default/service.tmpl
+++ b/build/templates/applications/rpm-package/default/service.tmpl
@@ -1,0 +1,50 @@
+[Unit]
+Description=Your service description here
+# Ensures the network is up before starting this service
+After=network-online.target
+# Wants=AnotherService.service: If AnotherService is being started, this service will be started too
+# Requires=AnotherService.service: This service will only start if AnotherService starts successfully
+
+[Service]
+# Type of the service:
+# simple (default if ExecStart is set, service considered started immediately)
+# forking (useful for services that fork a child process)
+# oneshot (useful for scripts that perform a task and exit)
+# dbus (if the service acquires a name on the D-Bus)
+# notify (if the service sends a notification message via sd_notify(3))
+# idle (delayed execution until all jobs are dispatched)
+Type=simple
+
+# The command to run to start the service. This setting is required.
+ExecStart=/path/to/your/command
+
+# The command to run to reload the service configuration without interrupting pending operations.
+#ExecReload=/path/to/reload/script
+
+# The command to run to stop the service.
+#ExecStop=/path/to/stop/script
+
+# Restart policy:
+# no (default if no ExecStart= is set)
+# on-success (only if service exited successfully)
+# on-failure (only on unclean exit)
+# on-abnormal (on timeout, signal, core dump)
+# on-watchdog (if watchdog timeout for the service expires)
+# on-abort (if service is aborted by a signal)
+# always (in all cases)
+#Restart=no
+
+# Time to sleep before restarting a service (e.g., 10s)
+#RestartSec=10
+
+# The user and group to run the service as.
+# User=root
+# Group=root
+
+# The working directory for the service.
+#WorkingDirectory=/path/to/working/directory
+
+
+[Install]
+# Specifies whether the service should start when the system boots.
+WantedBy=multi-user.target

--- a/build/templates/applications/rpm-package/default/spec.tmpl
+++ b/build/templates/applications/rpm-package/default/spec.tmpl
@@ -1,0 +1,63 @@
+%global source_date_epoch_from_changelog 0
+%define debug_package %{nil}
+
+%if 0%{?RELEASE_NUMBER:1} != 0
+%define rel %{?RELEASE_NUMBER}
+%else
+%define rel 1
+%endif
+
+%if 0%{?VERSION_NUMBER:1} != 0
+%define ver %{?VERSION_NUMBER}
+%else
+%define ver 0.1.0
+%endif
+
+Name:           {{.Name}}
+Version:        %{ver}
+Release:        %{rel}
+Summary:        {{.Name}} application
+ExclusiveArch:  %{_arch}
+
+License:        Apache-2.0
+URL:            {{.GitURL}}
+Source0:        %{name}-%{version}.tar.gz
+Source1:        %{name}.service
+
+Requires:       bash
+Requires(post): systemd
+Requires(preun): systemd
+Requires(postun): systemd
+
+%description
+{{.Name}} application
+
+%prep
+%setup -q
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_bindir}
+install -m 0755 %{name} %{buildroot}/%{_bindir}/%{name}
+
+# Install the systemd service file
+install -D -m 0644 %{SOURCE1} %{buildroot}/etc/systemd/system/%{name}.service
+
+%post
+# Reload systemd daemon and enable the service
+systemctl daemon-reload
+systemctl enable %{name}.service
+systemctl start %{name}.service
+
+%preun
+# Stop and disable the service before uninstall
+systemctl stop %{name}.service
+systemctl disable %{name}.service
+
+%postun
+# Reload systemd daemon after uninstall
+systemctl daemon-reload
+
+%files
+%{_bindir}/%{name}
+%config(noreplace) /etc/systemd/system/%{name}.service


### PR DESCRIPTION
## Description
This patch defines the default template for rpm.spec and service files. It is needed to establish a standard structure for these files.

Related issue #123 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
tested on env

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

