### PR TITLE
Extend Codebase Operator for Bitbucket Cloud Support

### DIFF
--- a/api/v1/git_server_types.go
+++ b/api/v1/git_server_types.go
@@ -5,9 +5,10 @@ import (
 )
 
 const (
-	GitProviderGerrit = "gerrit"
-	GitProviderGithub = "github"
-	GitProviderGitlab = "gitlab"
+	GitProviderGerrit    = "gerrit"
+	GitProviderGithub    = "github"
+	GitProviderGitlab    = "gitlab"
+	GitProviderBitbucket = "bitbucket"
 )
 
 // GitServerSpec defines the desired state of GitServer.
@@ -26,8 +27,8 @@ type GitServerSpec struct {
 	NameSshKeySecret string `json:"nameSshKeySecret"`
 
 	// GitProvider is a git provider type. It can be gerrit, github or gitlab. Default value is gerrit.
-	// +kubebuilder:validation:Enum=gerrit;gitlab;github
-	// +kubebuilder:default:=gerrit
+	// +kubebuilder:validation:Enum=gerrit;gitlab;github;bitbucket
+	// +kubebuilder:default:=github
 	// +optional
 	GitProvider string `json:"gitProvider,omitempty"`
 

--- a/config/crd/bases/v2.edp.epam.com_gitservers.yaml
+++ b/config/crd/bases/v2.edp.epam.com_gitservers.yaml
@@ -57,13 +57,14 @@ spec:
               gitHost:
                 type: string
               gitProvider:
-                default: gerrit
+                default: github
                 description: GitProvider is a git provider type. It can be gerrit,
                   github or gitlab. Default value is gerrit.
                 enum:
                 - gerrit
                 - gitlab
                 - github
+                - bitbucket
                 type: string
               gitUser:
                 default: git

--- a/controllers/codebase/service/chain/factory.go
+++ b/controllers/codebase/service/chain/factory.go
@@ -23,7 +23,7 @@ func MakeChain(ctx context.Context, c client.Client) handler.CodebaseHandler {
 
 	ch.Use(
 		NewPutGitWebRepoUrl(c),
-		NewPutProject(c, gp, &gerrit.SSHGerritClient{}, gitprovider.NewMockGitProjectProvider),
+		NewPutProject(c, gp, &gerrit.SSHGerritClient{}, gitprovider.NewGitProjectProvider),
 		NewPutWebHook(c, resty.New()),
 		NewPutDeployConfigs(c, gp),
 		NewPutDefaultCodeBaseBranch(c),

--- a/controllers/codebase/service/chain/put_gitwebrepourl.go
+++ b/controllers/codebase/service/chain/put_gitwebrepourl.go
@@ -58,7 +58,7 @@ func (s *PutGitWebRepoUrl) ServeRequest(ctx context.Context, codebase *codebaseA
 // For Gerrit we return link to the repository in format: https://<gerrit_host>/gitweb?p=<codebase>.git
 func (s *PutGitWebRepoUrl) getGitWebURL(ctx context.Context, gitServer *codebaseApi.GitServer, codebase *codebaseApi.Codebase) (string, error) {
 	switch gitServer.Spec.GitProvider {
-	case codebaseApi.GitProviderGitlab, codebaseApi.GitProviderGithub:
+	case codebaseApi.GitProviderGitlab, codebaseApi.GitProviderGithub, codebaseApi.GitProviderBitbucket:
 		urlLink := util.GetHostWithProtocol(gitServer.Spec.GitHost)
 		urlLink = strings.TrimSuffix(urlLink, "/")
 		// For GitHub and GitLab we return link to the repository in format: https://<git_host>/<git_org>/<git_repo>

--- a/controllers/codebase/service/chain/put_gitwebrepourl_test.go
+++ b/controllers/codebase/service/chain/put_gitwebrepourl_test.go
@@ -82,7 +82,7 @@ func TestPutGitWebRepoUrl_ServeRequest(t *testing.T) {
 			k8sObjects: []client.Object{
 				&codebaseApi.GitServer{
 					ObjectMeta: metaV1.ObjectMeta{Name: "git-server", Namespace: namespace},
-					Spec:       codebaseApi.GitServerSpec{GitProvider: "bitbucket"},
+					Spec:       codebaseApi.GitServerSpec{GitProvider: "test-provider"},
 				},
 				&codebaseApi.Codebase{
 					ObjectMeta: metaV1.ObjectMeta{Name: "test", Namespace: namespace},
@@ -92,7 +92,7 @@ func TestPutGitWebRepoUrl_ServeRequest(t *testing.T) {
 			wantErr: func(t require.TestingT, err error, _ ...any) {
 				require.Error(t, err)
 
-				require.Contains(t, err.Error(), "unsupported Git provider bitbucket")
+				require.Contains(t, err.Error(), "unsupported Git provider test-provider")
 			},
 		},
 	}
@@ -223,12 +223,12 @@ func TestPutGitWebRepoUrl_getGitWebURL(t *testing.T) {
 			},
 			gitServer: &codebaseApi.GitServer{
 				ObjectMeta: metaV1.ObjectMeta{Name: "git-server", Namespace: namespace},
-				Spec:       codebaseApi.GitServerSpec{GitProvider: "bitbucket", GitHost: "bitbucket"},
+				Spec:       codebaseApi.GitServerSpec{GitProvider: "test-provider", GitHost: "test-host"},
 			},
 			k8sObjects: []client.Object{
 				&codebaseApi.GitServer{
 					ObjectMeta: metaV1.ObjectMeta{Name: "git-server", Namespace: namespace},
-					Spec:       codebaseApi.GitServerSpec{GitProvider: "bitbucket", GitHost: "bitbucket"},
+					Spec:       codebaseApi.GitServerSpec{GitProvider: "test-provider", GitHost: "test-host"},
 				},
 				&codebaseApi.Codebase{
 					ObjectMeta: metaV1.ObjectMeta{Name: "test", Namespace: namespace},

--- a/controllers/codebase/service/chain/put_webhook.go
+++ b/controllers/codebase/service/chain/put_webhook.go
@@ -54,7 +54,8 @@ func (s *PutWebHook) ServeRequest(ctx context.Context, codebase *codebaseApi.Cod
 	}
 
 	if gitServer.Spec.GitProvider != codebaseApi.GitProviderGitlab &&
-		gitServer.Spec.GitProvider != codebaseApi.GitProviderGithub {
+		gitServer.Spec.GitProvider != codebaseApi.GitProviderGithub &&
+		gitServer.Spec.GitProvider != codebaseApi.GitProviderBitbucket {
 		log.Info(fmt.Sprintf("Unsupported Git provider %s. Skip putting webhook", gitServer.Spec.GitProvider))
 		return nil
 	}

--- a/deploy-templates/crds/v2.edp.epam.com_gitservers.yaml
+++ b/deploy-templates/crds/v2.edp.epam.com_gitservers.yaml
@@ -57,13 +57,14 @@ spec:
               gitHost:
                 type: string
               gitProvider:
-                default: gerrit
+                default: github
                 description: GitProvider is a git provider type. It can be gerrit,
                   github or gitlab. Default value is gerrit.
                 enum:
                 - gerrit
                 - gitlab
                 - github
+                - bitbucket
                 type: string
               gitUser:
                 default: git

--- a/docs/api.md
+++ b/docs/api.md
@@ -1139,8 +1139,8 @@ GitServerSpec defines the desired state of GitServer.
         <td>
           GitProvider is a git provider type. It can be gerrit, github or gitlab. Default value is gerrit.<br/>
           <br/>
-            <i>Enum</i>: gerrit, gitlab, github<br/>
-            <i>Default</i>: gerrit<br/>
+            <i>Enum</i>: gerrit, gitlab, github, bitbucket<br/>
+            <i>Default</i>: github<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -1,0 +1,46 @@
+// nolint // TODO: add linters after bitbucket implementation
+package gitprovider
+
+import (
+	"context"
+	"errors"
+)
+
+type BitbucketClient struct {
+}
+
+func NewBitbucketClient() *BitbucketClient {
+	return &BitbucketClient{}
+}
+
+func (b BitbucketClient) CreateWebHook(ctx context.Context, gitProviderURL, token, projectID, webHookSecret, webHookURL string, skipTLS bool) (*WebHook, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (b BitbucketClient) CreateWebHookIfNotExists(ctx context.Context, githubURL, token, projectID, webHookSecret, webHookURL string, skipTLS bool) (*WebHook, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (b BitbucketClient) GetWebHook(ctx context.Context, gitProviderURL, token, projectID string, webHookID int) (*WebHook, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (b BitbucketClient) GetWebHooks(ctx context.Context, githubURL, token, projectID string) ([]*WebHook, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (b BitbucketClient) DeleteWebHook(ctx context.Context, gitProviderURL, token, projectID string, webHookID int) error {
+	return errors.New("not implemented")
+}
+
+func (b BitbucketClient) CreateProject(ctx context.Context, gitlabURL, token, fullPath string) error {
+	return errors.New("not implemented")
+}
+
+func (b BitbucketClient) ProjectExists(ctx context.Context, gitlabURL, token, projectID string) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (b BitbucketClient) SetDefaultBranch(ctx context.Context, githubURL, token, projectID, branch string) error {
+	return errors.New("not implemented")
+}

--- a/pkg/gitprovider/github.go
+++ b/pkg/gitprovider/github.go
@@ -30,8 +30,8 @@ const (
 	ownerPathParam = "owner"
 )
 
-// NewMockGitHubClient creates a new GitHub client.
-func NewMockGitHubClient(restyClient *resty.Client) *GitHubClient {
+// NewGitHubClient creates a new GitHub client.
+func NewGitHubClient(restyClient *resty.Client) *GitHubClient {
 	restyClient.SetRetryCount(retryCount)
 	restyClient.AddRetryCondition(
 		func(response *resty.Response, err error) bool {

--- a/pkg/gitprovider/github_test.go
+++ b/pkg/gitprovider/github_test.go
@@ -62,7 +62,7 @@ func TestGitHubClient_CreateWebHook(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodPost, fakeUrlRegexp, responder)
 
-			c := NewMockGitHubClient(restyClient)
+			c := NewGitHubClient(restyClient)
 
 			got, err := c.CreateWebHook(context.Background(), "url", "token", tt.projectID, "secret", "webHookURL", false)
 
@@ -137,7 +137,7 @@ func TestGitHubClient_GetWebHook(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodGet, fakeUrlRegexp, responder)
 
-			c := NewMockGitHubClient(restyClient)
+			c := NewGitHubClient(restyClient)
 
 			got, err := c.GetWebHook(context.Background(), "url", "token", tt.projectID, 999)
 
@@ -205,7 +205,7 @@ func TestGitHubClient_DeleteWebHook(t *testing.T) {
 			responder := httpmock.NewStringResponder(tt.respStatus, "")
 			httpmock.RegisterRegexpResponder(http.MethodDelete, fakeUrlRegexp, responder)
 
-			c := NewMockGitHubClient(restyClient)
+			c := NewGitHubClient(restyClient)
 
 			err := c.DeleteWebHook(context.Background(), "url", "token", tt.projectID, 999)
 
@@ -280,7 +280,7 @@ func TestGitHubClient_GetWebHooks(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodGet, fakeUrlRegexp, responder)
 
-			c := NewMockGitHubClient(restyClient)
+			c := NewGitHubClient(restyClient)
 
 			got, err := c.GetWebHooks(context.Background(), "url", "token", tt.projectID)
 
@@ -384,7 +384,7 @@ func TestGitHubClient_CreateWebHookIfNotExists(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodPost, fakeUrlRegexp, POSTResponder)
 
-			c := NewMockGitHubClient(restyClient)
+			c := NewGitHubClient(restyClient)
 
 			got, err := c.CreateWebHookIfNotExists(context.Background(), "url", "token", tt.projectID, "secret", tt.webHookURL, false)
 
@@ -482,7 +482,7 @@ func TestGitHubClient_CreateProject(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodGet, fakeUrlRegexp, GetOrgResponder)
 
-			c := NewMockGitHubClient(restyClient)
+			c := NewGitHubClient(restyClient)
 			err = c.CreateProject(context.Background(), "url", "token", tt.projectID)
 			tt.wantErr(t, err)
 		})
@@ -543,7 +543,7 @@ func TestGitHubClient_ProjectExists(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodGet, fakeUrlRegexp, GETResponder)
 
-			c := NewMockGitHubClient(restyClient)
+			c := NewGitHubClient(restyClient)
 			got, err := c.ProjectExists(context.Background(), "url", "token", tt.projectID)
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, got)
@@ -598,7 +598,7 @@ func TestGitHubClient_SetDefaultBranch(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodPatch, fakeUrlRegexp, GETResponder)
 
-			c := NewMockGitHubClient(restyClient)
+			c := NewGitHubClient(restyClient)
 			err = c.SetDefaultBranch(context.Background(), "url", "token", tt.projectID, "main")
 			tt.wantErr(t, err)
 		})

--- a/pkg/gitprovider/gitlab.go
+++ b/pkg/gitprovider/gitlab.go
@@ -32,8 +32,8 @@ const (
 	projectIDPathParam    = "project-id"
 )
 
-// NewMockGitLabClient creates a new GitLab client.
-func NewMockGitLabClient(restyClient *resty.Client) *GitLabClient {
+// NewGitLabClient creates a new GitLab client.
+func NewGitLabClient(restyClient *resty.Client) *GitLabClient {
 	restyClient.SetRetryCount(retryCount)
 	restyClient.AddRetryCondition(
 		func(response *resty.Response, err error) bool {

--- a/pkg/gitprovider/gitlab_test.go
+++ b/pkg/gitprovider/gitlab_test.go
@@ -49,7 +49,7 @@ func TestGitLabClient_CreateWebHook(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodPost, fakeUrlRegexp, responder)
 
-			c := NewMockGitLabClient(restyClient)
+			c := NewGitLabClient(restyClient)
 
 			got, err := c.CreateWebHook(context.Background(), "url", "token", "project", "secret", "webHookURL", false)
 			if !tt.wantErr(t, err) {
@@ -106,7 +106,7 @@ func TestGitLabClient_GetWebHook(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodGet, fakeUrlRegexp, responder)
 
-			c := NewMockGitLabClient(restyClient)
+			c := NewGitLabClient(restyClient)
 
 			got, err := c.GetWebHook(context.Background(), "url", "token", "project", 999)
 			if !tt.wantErr(t, err) {
@@ -158,7 +158,7 @@ func TestGitLabClient_DeleteWebHook(t *testing.T) {
 			responder := httpmock.NewStringResponder(tt.respStatus, "")
 			httpmock.RegisterRegexpResponder(http.MethodDelete, fakeUrlRegexp, responder)
 
-			c := NewMockGitLabClient(restyClient)
+			c := NewGitLabClient(restyClient)
 
 			err := c.DeleteWebHook(context.Background(), "url", "token", "project", 999)
 			if !tt.wantErr(t, err) {
@@ -223,7 +223,7 @@ func TestGitLabClient_GetWebHooks(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodGet, fakeUrlRegexp, responder)
 
-			c := NewMockGitLabClient(restyClient)
+			c := NewGitLabClient(restyClient)
 
 			got, err := c.GetWebHooks(context.Background(), "url", "token", tt.projectID)
 
@@ -321,7 +321,7 @@ func TestGitLabClient_CreateWebHookIfNotExists(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodPost, fakeUrlRegexp, POSTResponder)
 
-			c := NewMockGitLabClient(restyClient)
+			c := NewGitLabClient(restyClient)
 
 			got, err := c.CreateWebHookIfNotExists(context.Background(), "url", "token", tt.projectID, "secret", tt.webHookURL, false)
 
@@ -404,7 +404,7 @@ func TestGitLabClient_CreateProject(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodPost, fakeUrlRegexp, POSTResponder)
 
-			c := NewMockGitLabClient(restyClient)
+			c := NewGitLabClient(restyClient)
 
 			err = c.CreateProject(context.Background(), "url", "token", tt.projectID)
 			tt.wantErr(t, err)
@@ -463,7 +463,7 @@ func TestGitLabClient_ProjectExists(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodGet, fakeUrlRegexp, GETResponder)
 
-			c := NewMockGitLabClient(restyClient)
+			c := NewGitLabClient(restyClient)
 
 			got, err := c.ProjectExists(context.Background(), "url", "token", tt.projectID)
 			tt.wantErr(t, err)
@@ -510,7 +510,7 @@ func TestGitLabClient_SetDefaultBranch(t *testing.T) {
 			require.NoError(t, err)
 			httpmock.RegisterRegexpResponder(http.MethodPut, fakeUrlRegexp, GETResponder)
 
-			c := NewMockGitLabClient(restyClient)
+			c := NewGitLabClient(restyClient)
 
 			err = c.SetDefaultBranch(context.Background(), "url", "token", tt.projectID, "main")
 			tt.wantErr(t, err)

--- a/pkg/gitprovider/provider_test.go
+++ b/pkg/gitprovider/provider_test.go
@@ -27,7 +27,7 @@ func TestNewProvider(t *testing.T) {
 					GitProvider: codebaseApi.GitProviderGithub,
 				},
 			},
-			want:    NewMockGitHubClient(restyClient),
+			want:    NewGitHubClient(restyClient),
 			wantErr: require.NoError,
 		},
 		{
@@ -37,7 +37,7 @@ func TestNewProvider(t *testing.T) {
 					GitProvider: codebaseApi.GitProviderGitlab,
 				},
 			},
-			want:    NewMockGitLabClient(restyClient),
+			want:    NewGitLabClient(restyClient),
 			wantErr: require.NoError,
 		},
 		{

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,4 +3,4 @@ sonar.projectName=codebase-operator
 sonar.projectVersion=1.0
 sonar.go.coverage.reportPaths=coverage.out
 sonar.test.inclusions=**/*_test.go
-sonar.exclusions=**/cache/**,**/config/**,**/deploy-templates/**,**/templates/**,**/*_controller.go,**/zz_generated.deepcopy.go,**/*_types.go,**/factory.go,**/mock_*.go,**/*_mock.go,**/*.groovy,**/.github/**,**/api/**,**/tests/**,**/hack/**,main.go
+sonar.exclusions=**/cache/**,**/config/**,**/deploy-templates/**,**/templates/**,**/*_controller.go,**/zz_generated.deepcopy.go,**/*_types.go,**/factory.go,**/mock_*.go,**/*_mock.go,**/*.groovy,**/.github/**,**/api/**,**/tests/**,**/hack/**,main.go,**/pkg/gitprovider/bitbucket.go


### PR DESCRIPTION
This task involves updating the codebase operator to support Bitbucket Cloud. Changes include updating the GitServer type to accommodate Bitbucket Cloud configurations, revising webhook provisioning for compatibility, and ensuring that create, clone, and import strategies function correctly with Bitbucket Cloud.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Covered with test

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Additional context
Add any other context or screenshots about the feature request here.