### PR TITLE
fix: Ignore extra labels in CodebaseImageStream for auto-deploy

### DIFF
--- a/controllers/codebaseimagestream/chain/put_cd_stage_deploy_test.go
+++ b/controllers/codebaseimagestream/chain/put_cd_stage_deploy_test.go
@@ -355,6 +355,7 @@ func TestPutCDStageDeploy_ServeRequest(t *testing.T) {
 				Spec: codebaseApi.CodebaseImageStreamSpec{
 					Codebase:  "app",
 					ImageName: "latest",
+					Tags:      []codebaseApi.Tag{{Name: "latest", Created: time.Now().Format(time.RFC3339)}},
 				},
 			},
 			client: func(t *testing.T) client.Client {
@@ -363,11 +364,8 @@ func TestPutCDStageDeploy_ServeRequest(t *testing.T) {
 					WithObjects().
 					Build()
 			},
-			wantErr: func(t require.TestingT, err error, i ...interface{}) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "label must be in format cd-pipeline-name/stage-name")
-			},
-			want: func(t *testing.T, k8scl client.Client) {},
+			wantErr: require.NoError,
+			want:    func(t *testing.T, k8scl client.Client) {},
 		},
 		{
 			name: "failed to create CDStageDeploy - no tags",


### PR DESCRIPTION
# Pull Request Template

## Description
Ignore any extra labels in CodebaseImageStream during the creation of the CDStageDeploy.
Previously, such labels caused errors and blocked auto-deploy flow.

Fixes #153 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- Unit tests
- Manual testing

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.