### PR TITLE
fix: Processing default branch for bitbucket (#155)

### DIFF
--- a/controllers/codebase/service/chain/put_project.go
+++ b/controllers/codebase/service/chain/put_project.go
@@ -369,10 +369,10 @@ func (h *PutProject) setDefaultBranch(
 		codebase.Spec.GetProjectID(),
 		codebase.Spec.DefaultBranch,
 	); err != nil {
-		if errors.Is(gitprovider.ErrApiNotSupported, err) {
+		if errors.Is(err, gitprovider.ErrApiNotSupported) {
 			// We can skip this error, because it is not supported by Git provider.
 			// And this is not critical for the whole process.
-			log.Error(err, "Setting default branch is not supported by Git provider. Set it manually if needed")
+			log.Info("Setting default branch is not supported by Git provider. Set it manually if needed")
 
 			return nil
 		}

--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -269,12 +269,7 @@ func (b *BitbucketClient) ProjectExists(ctx context.Context, _, _, projectID str
 	return false, nil
 }
 
-func (*BitbucketClient) SetDefaultBranch(_ context.Context, _, _, _, branch string) error {
-	if branch == "main" {
-		// Bitbucket uses `main` as a default branch, so we can skip this operation.
-		return nil
-	}
-
+func (*BitbucketClient) SetDefaultBranch(_ context.Context, _, _, _, _ string) error {
 	// Set default branch is not supported by Bitbucket API.
 	// Open ticket: https://jira.atlassian.com/browse/BCLOUD-20340
 	// https://community.atlassian.com/t5/Bitbucket-questions/Get-and-set-default-branch-in-v2-API/qaq-p/2416227

--- a/pkg/gitprovider/bitbucket_test.go
+++ b/pkg/gitprovider/bitbucket_test.go
@@ -408,11 +408,6 @@ func TestBitbucketClient_SetDefaultBranch(t *testing.T) {
 				require.ErrorIs(t, err, ErrApiNotSupported)
 			},
 		},
-		{
-			name:    "skip main",
-			branch:  "main",
-			wantErr: require.NoError,
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixed:
- Error 'API not supported' while processing default branch for Codebase. Now, this error is logged, and don't block Codebase.
- The operator creates new branches from Codebase.spec.defaultBranch.

Fixes #158 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Pull Request contains one commit. I squash my commits.