### PR TITLE
feat: Add validation webhook for protected resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV ASSETS_DIR=/usr/local/bin \
     USER_UID=1001
 
 RUN apk add --no-cache ca-certificates=20241121-r1 \
-                       openssh-client==9.3_p2-r2 \
+                       openssh-client==9.3_p2-r3  \
                        git==2.40.4-r0
 
 RUN adduser -h ${HOME} -s /bin/ash -D -u ${USER_UID} codebase-operator

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -10,6 +10,66 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-v2-edp-epam-com-v1-codebasebranch
+  failurePolicy: Fail
+  name: codebasebranch.epam.com
+  rules:
+  - apiGroups:
+    - v2.edp.epam.com
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - codebasebranchs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-v2-edp-epam-com-v1-codebaseimagestream
+  failurePolicy: Fail
+  name: codebaseimagestream.epam.com
+  rules:
+  - apiGroups:
+    - v2.edp.epam.com
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - codebaseimagestreams
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-v2-edp-epam-com-v1-gitserver
+  failurePolicy: Fail
+  name: gitserver.epam.com
+  rules:
+  - apiGroups:
+    - v2.edp.epam.com
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - gitservers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-v2-edp-epam-com-v1-codebase
   failurePolicy: Fail
   name: vcodebase.kb.io
@@ -21,6 +81,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - codebases
   sideEffects: None

--- a/deploy-templates/templates/validation_webhook.yaml
+++ b/deploy-templates/templates/validation_webhook.yaml
@@ -11,6 +11,80 @@ webhooks:
       service:
         name: edp-codebase-operator-webhook-service
         namespace: {{ .Release.Namespace }}
+        path: /validate-v2-edp-epam-com-v1-codebasebranch
+    failurePolicy: Fail
+    name: codebasebranch.epam.com
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+            - {{ .Release.Namespace }}
+    rules:
+      - apiGroups:
+          - v2.edp.epam.com
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+          - DELETE
+        resources:
+          - codebasebranchs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: edp-codebase-operator-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-v2-edp-epam-com-v1-codebaseimagestream
+    failurePolicy: Fail
+    name: codebaseimagestream.epam.com
+    rules:
+      - apiGroups:
+          - v2.edp.epam.com
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+          - DELETE
+        resources:
+          - codebaseimagestreams
+        scope: Namespaced
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: edp-codebase-operator-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-v2-edp-epam-com-v1-gitserver
+    failurePolicy: Fail
+    name: gitserver.epam.com
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+            - {{ .Release.Namespace }}
+    rules:
+      - apiGroups:
+          - v2.edp.epam.com
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+          - DELETE
+        resources:
+          - gitservers
+        scope: Namespaced
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: edp-codebase-operator-webhook-service
+        namespace: {{ .Release.Namespace }}
         path: /validate-v2-edp-epam-com-v1-codebase
     failurePolicy: Fail
     name: vcodebase.kb.io
@@ -28,6 +102,7 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+          - DELETE
         resources:
           - codebases
         scope: Namespaced

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/jarcoal/httpmock v1.0.8
 	github.com/oapi-codegen/runtime v1.1.1
+	github.com/onsi/ginkgo/v2 v2.19.0
+	github.com/onsi/gomega v1.34.1
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/stretchr/testify v1.10.0
 	github.com/tektoncd/pipeline v0.59.0
@@ -61,6 +63,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
+	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -71,6 +74,7 @@ require (
 	github.com/google/go-containerregistry v0.19.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -122,7 +126,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/grpc v1.63.2 // indirect
-	google.golang.org/protobuf v1.33.0 // indirect
+	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -294,8 +294,8 @@ github.com/go-resty/resty/v2 v2.6.0 h1:joIR5PNLM2EFqqESUjCMGXrWmXNHEU9CEiK813oKY
 github.com/go-resty/resty/v2 v2.6.0/go.mod h1:PwvJS6hvaPkjtjNg9ph+VrSD92bi5Zq73w/BIH7cC3Q=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
-github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
-github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
+github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
+github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/gobuffalo/flect v0.2.4/go.mod h1:1ZyCLIbg0YD7sDkzvFdPoOydPtD8y9JQnrOROolUcM8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
@@ -409,8 +409,9 @@ github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 h1:k7nVchz72niMH6YLQNvHSdIE7iqsQxK1P41mySCvssg=
+github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -587,10 +588,9 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
-github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
-github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
-github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
+github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA=
+github.com/onsi/ginkgo/v2 v2.19.0/go.mod h1:rlwLi9PilAFJ8jCg9UE1QP6VBpd6/xj3SRC0d6TU0To=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1335,8 +1335,8 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
-google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
+google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/webhook/protected_label.go
+++ b/pkg/webhook/protected_label.go
@@ -1,0 +1,118 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"slices"
+
+	codebaseApi "github.com/epam/edp-codebase-operator/v2/api/v1"
+)
+
+const (
+	protectedLabel  = "app.edp.epam.com/edit-protection"
+	deleteOperation = "delete"
+	updateOperation = "update"
+)
+
+//+kubebuilder:webhook:path=/validate-v2-edp-epam-com-v1-gitserver,mutating=false,failurePolicy=fail,sideEffects=None,groups=v2.edp.epam.com,resources=gitservers,verbs=update;delete,versions=v1,name=gitserver.epam.com,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-v2-edp-epam-com-v1-codebaseimagestream,mutating=false,failurePolicy=fail,sideEffects=None,groups=v2.edp.epam.com,resources=codebaseimagestreams,verbs=update;delete,versions=v1,name=codebaseimagestream.epam.com,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-v2-edp-epam-com-v1-codebasebranch,mutating=false,failurePolicy=fail,sideEffects=None,groups=v2.edp.epam.com,resources=codebasebranchs,verbs=update;delete,versions=v1,name=codebasebranch.epam.com,admissionReviewVersions=v1
+
+// ProtectedLabelValidationWebhook is a webhook for validating ProtectedLabel CRD.
+type ProtectedLabelValidationWebhook struct {
+}
+
+// SetupWebhookWithManager sets up the webhook with the manager for given resources.
+func (r *ProtectedLabelValidationWebhook) SetupWebhookWithManager(mgr ctrl.Manager, objects ...runtime.Object) error {
+	for _, obj := range objects {
+		err := ctrl.NewWebhookManagedBy(mgr).
+			For(obj).
+			WithValidator(r).
+			Complete()
+		if err != nil {
+			return fmt.Errorf("failed to build %s validation webhook: %w", obj.GetObjectKind().GroupVersionKind(), err)
+		}
+	}
+
+	return nil
+}
+
+// ValidateCreate is a webhook for validating the creation of the ProtectedLabel CR.
+func (*ProtectedLabelValidationWebhook) ValidateCreate(_ context.Context, _ runtime.Object) (warnings admission.Warnings, err error) {
+	return nil, nil
+}
+
+// ValidateUpdate is a webhook for validating the updating of the ProtectedLabel CR.
+func (*ProtectedLabelValidationWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	if err = checkResourceProtectionFromModificationOnUpdate(oldObj, newObj); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// ValidateDelete is a webhook for validating the deleting of the ProtectedLabel CR.
+func (*ProtectedLabelValidationWebhook) ValidateDelete(_ context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	if err = checkResourceProtectionFromModificationOnDelete(obj); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func hasProtectedLabel(obj runtime.Object, operation string) bool {
+	o, ok := obj.(metaV1.Object)
+	if !ok {
+		return false
+	}
+
+	return o.GetLabels()[protectedLabel] != "" &&
+		slices.Contains(strings.Split(o.GetLabels()[protectedLabel], "-"), operation)
+}
+
+func isSpecUpdated(oldObj, newObj runtime.Object) bool {
+	switch old := oldObj.(type) {
+	case *codebaseApi.Codebase:
+		if newCodebase, ok := newObj.(*codebaseApi.Codebase); ok {
+			return !equality.Semantic.DeepEqual(old.Spec, newCodebase.Spec)
+		}
+	case *codebaseApi.CodebaseBranch:
+		if newBranch, ok := newObj.(*codebaseApi.CodebaseBranch); ok {
+			return !equality.Semantic.DeepEqual(old.Spec, newBranch.Spec)
+		}
+	case *codebaseApi.CodebaseImageStream:
+		if newImageStream, ok := newObj.(*codebaseApi.CodebaseImageStream); ok {
+			return !equality.Semantic.DeepEqual(old.Spec, newImageStream.Spec)
+		}
+	case *codebaseApi.GitServer:
+		if newGitServer, ok := newObj.(*codebaseApi.GitServer); ok {
+			return !equality.Semantic.DeepEqual(old.Spec, newGitServer.Spec)
+		}
+	}
+
+	return false
+}
+
+func checkResourceProtectionFromModificationOnDelete(obj runtime.Object) error {
+	if hasProtectedLabel(obj, deleteOperation) {
+		return errors.New("resource contains label that protects it from deletion")
+	}
+
+	return nil
+}
+
+func checkResourceProtectionFromModificationOnUpdate(oldObj, newObj runtime.Object) error {
+	if hasProtectedLabel(newObj, updateOperation) && isSpecUpdated(oldObj, newObj) {
+		return errors.New("resource contains label that protects it from modification")
+	}
+
+	return nil
+}

--- a/pkg/webhook/protected_label_test.go
+++ b/pkg/webhook/protected_label_test.go
@@ -1,0 +1,109 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	codebaseApi "github.com/epam/edp-codebase-operator/v2/api/v1"
+)
+
+func TestProtectedLabelValidationWebhook_ValidateUpdate(t *testing.T) {
+	type args struct {
+		oldObj runtime.Object
+		newObj runtime.Object
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "should fail if resource contains label that protects it from modification",
+			args: args{
+				oldObj: &codebaseApi.CodebaseBranch{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{protectedLabel: updateOperation},
+					},
+					Spec: codebaseApi.CodebaseBranchSpec{
+						BranchName: "test-branch",
+					},
+				},
+				newObj: &codebaseApi.CodebaseBranch{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{protectedLabel: updateOperation},
+					},
+					Spec: codebaseApi.CodebaseBranchSpec{
+						BranchName: "test-branch2",
+					},
+				},
+			},
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "resource contains label that protects it from modification")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pr := &ProtectedLabelValidationWebhook{}
+			_, err := pr.ValidateUpdate(context.Background(), tt.args.oldObj, tt.args.newObj)
+			tt.wantErr(t, err)
+		})
+	}
+}
+
+func TestProtectedLabelValidationWebhook_ValidateDelete(t *testing.T) {
+	type args struct {
+		obj runtime.Object
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "should fail if resource contains label that protects it from modification",
+			args: args{
+				obj: &codebaseApi.GitServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{protectedLabel: deleteOperation},
+					},
+					Spec: codebaseApi.GitServerSpec{
+						GitHost: "test-git-host",
+					},
+				},
+			},
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "resource contains label that protects it from deletion")
+			},
+		},
+		{
+			name: "should pass if resource doesn't contain label that protects it from modification",
+			args: args{
+				obj: &codebaseApi.GitServer{
+					Spec: codebaseApi.GitServerSpec{
+						GitHost: "test-git-host",
+					},
+				},
+			},
+			wantErr: require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pr := &ProtectedLabelValidationWebhook{}
+			_, err := pr.ValidateDelete(context.Background(), tt.args.obj)
+
+			tt.wantErr(t, err)
+		})
+	}
+}

--- a/pkg/webhook/webhook_suite_test.go
+++ b/pkg/webhook/webhook_suite_test.go
@@ -1,0 +1,66 @@
+package webhook
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	codebaseApi "github.com/epam/edp-codebase-operator/v2/api/v1"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.Background())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	sc := runtime.NewScheme()
+	Expect(scheme.AddToScheme(sc)).NotTo(HaveOccurred())
+	Expect(codebaseApi.AddToScheme(sc)).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: sc})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1,0 +1,83 @@
+package webhook
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+var _ = Describe("webhooks registration", func() {
+	When("ValidatingWebhookConfiguration exists", func() {
+		BeforeEach(func() {
+			By("creating ValidatingWebhookConfiguration")
+			webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: ctrl.ObjectMeta{
+					Name: getValidationWebHookName("default"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, webhook)).ToNot(HaveOccurred())
+		})
+		AfterEach(func() {
+			webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: ctrl.ObjectMeta{
+					Name: getValidationWebHookName("default"),
+				},
+			}
+			err := ctrlclient.IgnoreNotFound(k8sClient.Delete(ctx, webhook))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should register validation webhooks", func() {
+			By("creating manager")
+			k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+				Scheme: k8sClient.Scheme(),
+				Metrics: metricsserver.Options{
+					BindAddress: "0",
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("registering validation webhooks")
+			err = RegisterValidationWebHook(ctx, k8sManager, "default")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		When("scheme doesn't contain cdpipeline types", func() {
+			It("should return error", func() {
+				By("creating manager")
+				k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+					Scheme: scheme.Scheme,
+					Metrics: metricsserver.Options{
+						BindAddress: "0",
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("registering validation webhooks")
+				err = RegisterValidationWebHook(ctx, k8sManager, "default")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+	When("MutatingWebhookConfiguration doesn't exist", func() {
+		It("should return error", func() {
+			By("creating manager")
+			k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+				Scheme: k8sClient.Scheme(),
+				Metrics: metricsserver.Options{
+					BindAddress: "0",
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("registering mutation webhooks")
+			err = RegisterValidationWebHook(ctx, k8sManager, "default")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
# Pull Request Template

## Description
To protect resources from deletion/updating added label `app.edp.epam.com/edit-protection`.
The label can have values: delete update delete-update

Fixes #176 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Unit tests
- Manual testing

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
