### PR TITLE
fix: CodebaseImageStream labels break auto-deploy

### DIFF
--- a/controllers/codebaseimagestream/chain/put_cd_stage_deploy.go
+++ b/controllers/codebaseimagestream/chain/put_cd_stage_deploy.go
@@ -60,16 +60,17 @@ func (h PutCDStageDeploy) handleCodebaseImageStreamEnvLabels(ctx context.Context
 
 	labelValueRegexp := regexp.MustCompile("^[-A-Za-z0-9_.]+/[-A-Za-z0-9_.]+$")
 
-	for envLabel := range imageStream.ObjectMeta.Labels {
-		if !labelValueRegexp.MatchString(envLabel) {
-			l.Info("Label value does not match the pattern cd-pipeline-name/stage-name. Skip CDStageDeploy creating.")
+	for envLabel, val := range imageStream.ObjectMeta.Labels {
+		// pipeline lable should be in format cdpipeline/stage-name: ""
+		if labelValueRegexp.MatchString(envLabel) && val == "" {
+			if err := h.putCDStageDeploy(ctx, envLabel, imageStream.Namespace, imageStream.Spec); err != nil {
+				return err
+			}
 
 			continue
 		}
 
-		if err := h.putCDStageDeploy(ctx, envLabel, imageStream.Namespace, imageStream.Spec); err != nil {
-			return err
-		}
+		l.Info("Label value does not match the pattern cd-pipeline-name/stage-name. Skip CDStageDeploy creating.")
 	}
 
 	return nil

--- a/controllers/codebaseimagestream/chain/put_cd_stage_deploy_test.go
+++ b/controllers/codebaseimagestream/chain/put_cd_stage_deploy_test.go
@@ -39,7 +39,8 @@ func TestPutCDStageDeploy_ServeRequest(t *testing.T) {
 					Name:      "test-image-stream",
 					Namespace: "default",
 					Labels: map[string]string{
-						"ci/dev": "",
+						"ci/dev":                        "",
+						codebaseApi.CodebaseBranchLabel: "test",
 					},
 				},
 				Spec: codebaseApi.CodebaseImageStreamSpec{


### PR DESCRIPTION
# Pull Request Template

## Description
CodebaseImageStream labels break auto-deploy

Fixes #198 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Unit tests
- Manual testing

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
