### PR TITLE
refactor: Extract common git repository preparation logic (#229)

### DIFF
--- a/controllers/codebase/service/chain/common_test.go
+++ b/controllers/codebase/service/chain/common_test.go
@@ -5,13 +5,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	testify "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	codebaseApi "github.com/epam/edp-codebase-operator/v2/api/v1"
+	gitMocks "github.com/epam/edp-codebase-operator/v2/pkg/git/mocks"
 	"github.com/epam/edp-codebase-operator/v2/pkg/util"
 )
 
@@ -247,4 +251,231 @@ func TestUpdateGitStatusWithPatch_SequentialUpdates(t *testing.T) {
 	}, updated)
 	assert.NoError(t, err)
 	assert.Equal(t, util.ProjectTemplatesPushedStatus, updated.Status.Git)
+}
+
+func TestPrepareGitRepository(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, codebaseApi.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	gitServer := &codebaseApi.GitServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gitserver",
+			Namespace: fakeNamespace,
+		},
+		Spec: codebaseApi.GitServerSpec{
+			GitHost:          "github.com",
+			GitUser:          "git",
+			NameSshKeySecret: "git-secret",
+			SshPort:          22,
+			GitProvider:      codebaseApi.GitProviderGithub,
+		},
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "git-secret",
+			Namespace: fakeNamespace,
+		},
+		Data: map[string][]byte{
+			util.PrivateSShKeyName: []byte("test-ssh-key"),
+		},
+	}
+
+	tests := []struct {
+		name      string
+		codebase  *codebaseApi.Codebase
+		objects   []client.Object
+		gitClient func(t *testing.T) *gitMocks.MockGit
+		setup     func(t *testing.T)
+		wantErr   require.ErrorAssertionFunc
+		want      func(t *testing.T, gitCtx *GitRepositoryContext)
+	}{
+		{
+			name: "successfully prepare repository - clone required",
+			codebase: &codebaseApi.Codebase{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fakeName,
+					Namespace: fakeNamespace,
+				},
+				Spec: codebaseApi.CodebaseSpec{
+					GitServer:     gitServer.Name,
+					DefaultBranch: "main",
+					Strategy:      codebaseApi.Create,
+					GitUrlPath:    fakeName,
+				},
+			},
+			objects: []client.Object{gitServer, secret},
+			gitClient: func(t *testing.T) *gitMocks.MockGit {
+				m := gitMocks.NewMockGit(t)
+				m.On("CloneRepositoryBySsh",
+					testify.Anything, "test-ssh-key", "git",
+					testify.Anything, testify.Anything, int32(22),
+				).Return(nil)
+				m.On("GetCurrentBranchName", testify.Anything).Return("main", nil)
+				m.On("CheckPermissions", testify.Anything, testify.Anything, testify.Anything, testify.Anything).Return(true)
+				return m
+			},
+			wantErr: require.NoError,
+			want: func(t *testing.T, gitCtx *GitRepositoryContext) {
+				require.NotNil(t, gitCtx)
+				assert.Equal(t, "test-ssh-key", gitCtx.PrivateSSHKey)
+				assert.Equal(t, gitServer.Name, gitCtx.GitServer.Name)
+				assert.Equal(t, secret.Name, gitCtx.Secret.Name)
+				assert.NotEmpty(t, gitCtx.RepoSSHUrl)
+				assert.NotEmpty(t, gitCtx.WorkDir)
+			},
+		},
+		{
+			name: "failed to get GitServer",
+			codebase: &codebaseApi.Codebase{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fakeName,
+					Namespace: fakeNamespace,
+				},
+				Spec: codebaseApi.CodebaseSpec{
+					GitServer:     "missing-gitserver",
+					DefaultBranch: "main",
+				},
+			},
+			gitClient: func(t *testing.T) *gitMocks.MockGit {
+				return gitMocks.NewMockGit(t)
+			},
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "failed to get GitServer")
+			},
+			want: func(t *testing.T, gitCtx *GitRepositoryContext) {
+				assert.Nil(t, gitCtx)
+			},
+		},
+		{
+			name: "failed to get GitServer secret",
+			codebase: &codebaseApi.Codebase{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fakeName,
+					Namespace: fakeNamespace,
+				},
+				Spec: codebaseApi.CodebaseSpec{
+					GitServer:     gitServer.Name,
+					DefaultBranch: "main",
+				},
+			},
+			objects: []client.Object{gitServer},
+			gitClient: func(t *testing.T) *gitMocks.MockGit {
+				return gitMocks.NewMockGit(t)
+			},
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "failed to get GitServer secret")
+			},
+			want: func(t *testing.T, gitCtx *GitRepositoryContext) {
+				assert.Nil(t, gitCtx)
+			},
+		},
+		{
+			name: "failed to clone repository",
+			codebase: &codebaseApi.Codebase{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fakeName,
+					Namespace: fakeNamespace,
+				},
+				Spec: codebaseApi.CodebaseSpec{
+					GitServer:     gitServer.Name,
+					DefaultBranch: "main",
+					Strategy:      codebaseApi.Create,
+				},
+			},
+			objects: []client.Object{gitServer, secret},
+			gitClient: func(t *testing.T) *gitMocks.MockGit {
+				m := gitMocks.NewMockGit(t)
+				m.On("CloneRepositoryBySsh", testify.Anything, testify.Anything, testify.Anything, testify.Anything, testify.Anything, testify.Anything).
+					Return(assert.AnError)
+				return m
+			},
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "failed to clone git repository")
+			},
+			want: func(t *testing.T, gitCtx *GitRepositoryContext) {
+				assert.Nil(t, gitCtx)
+			},
+		},
+		{
+			name: "failed to checkout default branch",
+			codebase: &codebaseApi.Codebase{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fakeName,
+					Namespace: fakeNamespace,
+				},
+				Spec: codebaseApi.CodebaseSpec{
+					GitServer:     gitServer.Name,
+					DefaultBranch: "main",
+					Strategy:      codebaseApi.Create,
+					GitUrlPath:    fakeName,
+					Repository:    &codebaseApi.Repository{Url: "https://github.com/test/repo.git"},
+				},
+			},
+			objects: []client.Object{
+				gitServer,
+				secret,
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "repository-codebase-fake-name-temp",
+						Namespace: fakeNamespace,
+					},
+					Data: map[string][]byte{
+						"username": []byte("user"),
+						"password": []byte("pass"),
+					},
+				},
+			},
+			gitClient: func(t *testing.T) *gitMocks.MockGit {
+				m := gitMocks.NewMockGit(t)
+				m.On("CloneRepositoryBySsh", testify.Anything, testify.Anything, testify.Anything, testify.Anything, testify.Anything, testify.Anything).
+					Return(nil)
+				m.On("CheckPermissions", testify.Anything, testify.Anything, testify.Anything, testify.Anything).
+					Return(false)
+				return m
+			},
+			wantErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "cannot get access to the repository")
+			},
+			want: func(t *testing.T, gitCtx *GitRepositoryContext) {
+				assert.Nil(t, gitCtx)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Setenv(util.WorkDirEnv, tmpDir)
+
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+
+			allObjects := append(tt.objects, tt.codebase)
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(allObjects...).
+				Build()
+
+			gitCtx, err := PrepareGitRepository(
+				context.Background(),
+				k8sClient,
+				tt.gitClient(t),
+				tt.codebase,
+			)
+
+			tt.wantErr(t, err)
+
+			if tt.want != nil {
+				tt.want(t, gitCtx)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Consolidate duplicated git repository setup code across chain handlers into a reusable PrepareGitRepository function and GitRepositoryContext struct.

Changes:
- Add GitRepositoryContext struct to hold git operation context
- Add PrepareGitRepository function for common git setup workflow
- Refactor PutDeployConfigs to use PrepareGitRepository
- Refactor PutGitLabCIConfig to use PrepareGitRepository
- Add comprehensive unit tests for PrepareGitRepository

This reduces code duplication and improves maintainability by centralizing GitServer retrieval, SSH credential extraction, repository cloning, and branch checkout logic.

Fixes #229

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

