### PR TITLE
fix: Raise pod memory to prevent clone OOM

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -40,9 +40,9 @@ A Helm chart for KubeRocketCI Codebase Operator
 | name | string | `"codebase-operator"` | component name |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{"runAsNonRoot":true}` | Pod Security Context Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
-| resources.limits.memory | string | `"192Mi"` |  |
+| resources.limits.memory | string | `"1Gi"` |  |
 | resources.requests.cpu | string | `"50m"` |  |
-| resources.requests.memory | string | `"64Mi"` |  |
+| resources.requests.memory | string | `"256Mi"` |  |
 | securityContext | object | `{"allowPrivilegeEscalation":false}` | Container Security Context Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | telemetryEnabled | bool | `true` | Flag to enable/disable telemetry |
 | tolerations | list | `[]` |  |

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -28,10 +28,10 @@ imagePullSecrets: []
 
 resources:
   limits:
-    memory: 192Mi
+    memory: 1Gi
   requests:
     cpu: 50m
-    memory: 64Mi
+    memory: 256Mi
 
 # -- Pod Security Context
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
# Pull Request Template

## Description
Large repository clones were failing due to insufficient memory; the operator pod was OOMKilled mid-clone.
Increased memory requests/limits to support medium-sized repos. Extremely large repos may still need manual tuning.

Fixes #240 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Manually.

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.